### PR TITLE
功能与兼容性支持合并

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -32,3 +32,6 @@ dotnet add package BilibiliUtilities.Utils --version 0.0.1
 Bilibili UID:27609142
 
 代码缓慢更新中,非常慢
+
+___
+`EndianBitConverter` 来自 https://github.com/davidrea-MS/BitConverter

--- a/Src/BilibiliUtilities.Live/BilibiliUtilities.Live.csproj
+++ b/Src/BilibiliUtilities.Live/BilibiliUtilities.Live.csproj
@@ -12,12 +12,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="EndianBitConverter" Version="1.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\BilibiliUtilities.Utils\BilibiliUtilities.Utils.csproj" />
+      <ProjectReference Include="..\EndianBitConverter\EndianBitConverter.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Src/BilibiliUtilities.Live/BilibiliUtilities.Live.csproj
+++ b/Src/BilibiliUtilities.Live/BilibiliUtilities.Live.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.0.1</PackageVersion>
+        <PackageVersion>0.0.2</PackageVersion>
         <Title>BilibiliUtilities-Live</Title>
         <Description>Provide support for real-time message distribution in bilibili live room</Description>
         <PackageProjectUrl>https://github.com/is-a-gamer/BilibiliUtilities</PackageProjectUrl>
         <PackageTags>Bilibili</PackageTags>
+        <Version>0.0.3</Version>
+        <TargetFrameworks>net471;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,6 +18,10 @@
 
     <ItemGroup>
       <ProjectReference Include="..\BilibiliUtilities.Utils\BilibiliUtilities.Utils.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net471'" />
     </ItemGroup>
 
 </Project>

--- a/Src/BilibiliUtilities.Live/Lib/DanmuHead.cs
+++ b/Src/BilibiliUtilities.Live/Lib/DanmuHead.cs
@@ -1,5 +1,4 @@
 using System;
-using BitConverter;
 
 namespace BilibiliUtilities.Live.Lib
 {
@@ -48,11 +47,11 @@ namespace BilibiliUtilities.Live.Lib
 
             return new DanmuHead
             {
-                PacketLength = EndianBitConverter.BigEndian.ToInt32(buffer, 0),
-                HeaderLength = EndianBitConverter.BigEndian.ToInt16(buffer, 4),
-                Version = EndianBitConverter.BigEndian.ToInt16(buffer, 6),
-                Action = EndianBitConverter.BigEndian.ToInt32(buffer, 8),
-                Parameter = EndianBitConverter.BigEndian.ToInt32(buffer, 12),
+                PacketLength = EndianBitConverter.EndianBitConverter.BigEndian.ToInt32(buffer, 0),
+                HeaderLength = EndianBitConverter.EndianBitConverter.BigEndian.ToInt16(buffer, 4),
+                Version = EndianBitConverter.EndianBitConverter.BigEndian.ToInt16(buffer, 6),
+                Action = EndianBitConverter.EndianBitConverter.BigEndian.ToInt32(buffer, 8),
+                Parameter = EndianBitConverter.EndianBitConverter.BigEndian.ToInt32(buffer, 12),
             };
         }
 

--- a/Src/BilibiliUtilities.Live/Lib/IMessageDispatcher.cs
+++ b/Src/BilibiliUtilities.Live/Lib/IMessageDispatcher.cs
@@ -1,4 +1,4 @@
-﻿﻿using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace BilibiliUtilities.Live.Lib

--- a/Src/BilibiliUtilities.Live/Lib/MessageDispatcher.cs
+++ b/Src/BilibiliUtilities.Live/Lib/MessageDispatcher.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using BilibiliUtilities.Live.Message;

--- a/Src/BilibiliUtilities.Live/LiveRoom.cs
+++ b/Src/BilibiliUtilities.Live/LiveRoom.cs
@@ -8,7 +8,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using BilibiliUtilities.Live.Lib;
-using BitConverter;
+using EndianBitConverter;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using BilibiliUtilities.Utils.LiveUtils;
@@ -133,7 +133,7 @@ namespace BilibiliUtilities.Live
                     //给服务器发送心跳信息后的回应信息,所带的数据是直播间的观看人数(人气值)
                     dataBuffer = new byte[danmuHead.MessageLength()];
                     await _roomStream.ReadAsync(dataBuffer, 0, danmuHead.MessageLength());
-                    var audiences = EndianBitConverter.BigEndian.ToInt32(dataBuffer, 0);
+                    var audiences = EndianBitConverter.EndianBitConverter.BigEndian.ToInt32(dataBuffer, 0);
                     _messageHandler.AudiencesHandlerAsync(audiences);
                     continue;
                 }
@@ -248,11 +248,11 @@ namespace BilibiliUtilities.Live
 
             var buffer = new byte[packageLength];
             var ms = new MemoryStream(buffer);
-            await ms.WriteAsync(EndianBitConverter.BigEndian.GetBytes(buffer.Length), 0, 4);
-            await ms.WriteAsync(EndianBitConverter.BigEndian.GetBytes(headLength), 0, 2);
-            await ms.WriteAsync(EndianBitConverter.BigEndian.GetBytes(version), 0, 2);
-            await ms.WriteAsync(EndianBitConverter.BigEndian.GetBytes(action), 0, 4);
-            await ms.WriteAsync(EndianBitConverter.BigEndian.GetBytes(param), 0, 4);
+            await ms.WriteAsync(EndianBitConverter.EndianBitConverter.BigEndian.GetBytes(buffer.Length), 0, 4);
+            await ms.WriteAsync(EndianBitConverter.EndianBitConverter.BigEndian.GetBytes(headLength), 0, 2);
+            await ms.WriteAsync(EndianBitConverter.EndianBitConverter.BigEndian.GetBytes(version), 0, 2);
+            await ms.WriteAsync(EndianBitConverter.EndianBitConverter.BigEndian.GetBytes(action), 0, 4);
+            await ms.WriteAsync(EndianBitConverter.EndianBitConverter.BigEndian.GetBytes(param), 0, 4);
             if (data.Length > 0)
             {
                 await ms.WriteAsync(data, 0, data.Length);

--- a/Src/BilibiliUtilities.Live/Message/BaseMessage.cs
+++ b/Src/BilibiliUtilities.Live/Message/BaseMessage.cs
@@ -1,4 +1,4 @@
-﻿﻿namespace BilibiliUtilities.Live.Message
+﻿namespace BilibiliUtilities.Live.Message
 {
     public class BaseMessage
     {

--- a/Src/BilibiliUtilities.Live/Message/DanmuMessage.cs
+++ b/Src/BilibiliUtilities.Live/Message/DanmuMessage.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Diagnostics;
 using System.Linq;
 using Newtonsoft.Json;

--- a/Src/BilibiliUtilities.Live/Message/EntryEffectMessage.cs
+++ b/Src/BilibiliUtilities.Live/Message/EntryEffectMessage.cs
@@ -1,5 +1,4 @@
 using System;
-using BitConverter;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/Src/BilibiliUtilities.Live/Message/GiftMessage.cs
+++ b/Src/BilibiliUtilities.Live/Message/GiftMessage.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/Src/BilibiliUtilities.Live/Message/WelcomeMessage.cs
+++ b/Src/BilibiliUtilities.Live/Message/WelcomeMessage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using BilibiliUtilities.Live.Message;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/Src/BilibiliUtilities.Test/BilibiliUtilities.Test.csproj
+++ b/Src/BilibiliUtilities.Test/BilibiliUtilities.Test.csproj
@@ -9,4 +9,9 @@
       <ProjectReference Include="..\BilibiliUtilities.Live\BilibiliUtilities.Live.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+      <PackageReference Include="xunit" Version="2.4.1" />
+    </ItemGroup>
+
 </Project>

--- a/Src/BilibiliUtilities.Test/LiveLib/LiveHandler.cs
+++ b/Src/BilibiliUtilities.Test/LiveLib/LiveHandler.cs
@@ -9,8 +9,10 @@ namespace BilibiliUtilities.Test.LiveLib
         //可以放置自己的参数用来使用,比如WPF的window对象
         public bool Param;
 
+        
         public async Task DanmuMessageHandlerAsync(DanmuMessage danmuMessage)
         {
+            
             Console.WriteLine($"发送者:{danmuMessage.Username},内容:{danmuMessage.Content}");
         }
 

--- a/Src/BilibiliUtilities.Test/Tests/LiveTest.cs
+++ b/Src/BilibiliUtilities.Test/Tests/LiveTest.cs
@@ -1,17 +1,21 @@
 ﻿using System;
 using BilibiliUtilities.Live;
-namespace BilibiliUtilities.Test
+using Xunit;
+
+namespace BilibiliUtilities.Test.Tests
 {
-    internal static class Program
+    public class LiveTest
     {
-        public static void Main(string[] args)
+
+        [Fact]
+        public static void TestLive()
         {
             Console.WriteLine("直播间房间号:");
             Start();
             Console.ReadLine();
         }
 
-        private static async void Start()
+        public static async void Start()
         {
             var liveHandler = new LiveLib.LiveHandler();
             var sroomid = Console.ReadLine();

--- a/Src/BilibiliUtilities.Test/Tests/VideoTest.cs
+++ b/Src/BilibiliUtilities.Test/Tests/VideoTest.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using BilibiliUtilities.Utils.CentralUtils;
+using Xunit;
+
+namespace BilibiliUtilities.Test.Tests
+{
+    public class VideoTest
+    {
+        [Fact]
+        public static async void TestAvToBv()
+        {
+            var BvId = await VideoUtil.AvToBv(170001);
+            Console.WriteLine(BvId);
+        }
+
+        [Fact]
+        public static async void TestBvToAv()
+        {
+            var AvId = await VideoUtil.BvToAv("BV17x411w7KC");
+            Console.WriteLine(AvId);
+        }
+    }
+}

--- a/Src/BilibiliUtilities.Utils/BilibiliUtilities - Backup.Utils.csproj
+++ b/Src/BilibiliUtilities.Utils/BilibiliUtilities - Backup.Utils.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -7,18 +7,12 @@
         <Description>Basic functional support for bilibilibiliutilities and users</Description>
         <PackageProjectUrl>https://github.com/is-a-gamer/BilibiliUtilities</PackageProjectUrl>
         <PackageTags>Bilibili</PackageTags>
-        <LangVersion>7.3</LangVersion>
-        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-        <Version>0.03</Version>
-        <TargetFrameworks>net471;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+        <LangVersion>8</LangVersion>
+        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net471'" />
     </ItemGroup>
 
 </Project>

--- a/Src/BilibiliUtilities.Utils/CentralUtils/VideoUtil.cs
+++ b/Src/BilibiliUtilities.Utils/CentralUtils/VideoUtil.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BilibiliUtilities.Utils.CentralUtils
+{
+    public class VideoUtil
+    {
+        
+        private static readonly string _tb = "fZodR9XQDSUm21yCkr6zBqiveYah8bt4xsWpHnJE7jL5VG3guMTKNPAwcF";
+        private static readonly Dictionary<char, ulong> _tr = new Dictionary<char, ulong>();
+        private static readonly List<int> _s = new List<int> { 11, 10, 3, 8, 4, 6 };
+        private static readonly List<char> _r = new List<char>{ 'B', 'V', '1', 'n', 'n', '4', 'n', '1', 'n', '7', 'n', 'n' };
+        private static readonly ulong _xor = 177451812;
+        private const ulong Add = 8728348608;
+
+
+        public static async Task<ulong> BvToAv(string bv)
+        {
+
+            for (ulong i = 0; i < 58; ++i)
+            {
+                _tr[_tb[(int)i]] = i;
+            }
+            ulong r = 0;
+            for (int i = 0; i < 6; ++i)
+            {
+                r += _tr[bv[_s[i]]] * (ulong)Math.Pow(58, i);
+            }
+            return (r - Add) ^ _xor;
+        }
+        
+        public static async Task<string> AvToBv(ulong av)
+        {
+            for (ulong i = 0; i < 58; ++i)
+            {
+                _tr[_tb[(int)i]] = i;
+            }
+            av = (av ^ _xor) + Add;
+            for (int i = 0; i < 6; ++i)
+            {
+                _r[_s[i]] = _tb[(int)(av / (ulong)Math.Pow(58, i) % 58)];
+            }
+            return string.Join("", _r);
+        }
+    }
+}

--- a/Src/BilibiliUtilities.sln
+++ b/Src/BilibiliUtilities.sln
@@ -5,6 +5,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BilibiliUtilities.Utils", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BilibiliUtilities.Test", "BilibiliUtilities.Test\BilibiliUtilities.Test.csproj", "{97571412-F61C-4944-8CEC-CA407BD000C9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndianBitConverter", "EndianBitConverter\EndianBitConverter.csproj", "{39070DFB-3AC8-4B56-AF4B-1179EDEB038A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,5 +25,9 @@ Global
 		{97571412-F61C-4944-8CEC-CA407BD000C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97571412-F61C-4944-8CEC-CA407BD000C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97571412-F61C-4944-8CEC-CA407BD000C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39070DFB-3AC8-4B56-AF4B-1179EDEB038A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39070DFB-3AC8-4B56-AF4B-1179EDEB038A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39070DFB-3AC8-4B56-AF4B-1179EDEB038A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39070DFB-3AC8-4B56-AF4B-1179EDEB038A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Src/EndianBitConverter/BigEndianBitConverter.cs
+++ b/Src/EndianBitConverter/BigEndianBitConverter.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+namespace EndianBitConverter
+{
+    /// <summary>
+    /// A big-endian BitConverter that converts base data types to an array of bytes, and an array of bytes to base data types. All conversions are in
+    /// big-endian format regardless of machine architecture.
+    /// </summary>
+    internal class BigEndianBitConverter : EndianBitConverter
+    {
+        // Instance available from EndianBitConverter.BigEndian
+        internal BigEndianBitConverter() { }
+
+        public override bool IsLittleEndian { get; } = false;
+
+        public override byte[] GetBytes(short value)
+        {
+            return new byte[] { (byte)(value >> 8), (byte)value };
+        }
+
+        public override byte[] GetBytes(int value)
+        {
+            return new byte[] { (byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value };
+        }
+
+        public override byte[] GetBytes(long value)
+        {
+            return new byte[] {
+                (byte)(value >> 56), (byte)(value >> 48), (byte)(value >> 40), (byte)(value >> 32),
+                (byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value
+            };
+        }
+
+        public override short ToInt16(byte[] value, int startIndex)
+        {
+            this.CheckArguments(value, startIndex, sizeof(short));
+
+            return (short)((value[startIndex] << 8) | (value[startIndex + 1]));
+        }
+
+        public override int ToInt32(byte[] value, int startIndex)
+        {
+            this.CheckArguments(value, startIndex, sizeof(int));
+
+            return (value[startIndex] << 24) | (value[startIndex + 1] << 16) | (value[startIndex + 2] << 8) | (value[startIndex + 3]);
+        }
+
+        public override long ToInt64(byte[] value, int startIndex)
+        {
+            this.CheckArguments(value, startIndex, sizeof(long));
+
+            int highBytes = (value[startIndex] << 24) | (value[startIndex + 1] << 16) | (value[startIndex + 2] << 8) | (value[startIndex + 3]);
+            int lowBytes = (value[startIndex + 4] << 24) | (value[startIndex + 5] << 16) | (value[startIndex + 6] << 8) | (value[startIndex + 7]);
+            return ((uint)lowBytes | ((long)highBytes << 32));
+        }
+    }
+}

--- a/Src/EndianBitConverter/EndianBitConverter.cs
+++ b/Src/EndianBitConverter/EndianBitConverter.cs
@@ -1,0 +1,345 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace EndianBitConverter
+{
+    /// <summary>
+    /// A BitConverter with a specific endianness that converts base data types to an array of bytes, and an array of bytes to base data types, regardless of
+    /// machine architecture. Access the little-endian and big-endian converters with their respective properties.
+    /// </summary>
+    /// <remarks>
+    /// The EndianBitConverter implementations provide the same interface as <see cref="System.BitConverter"/>, but exclude those methods which perform the
+    /// same on both big-endian and little-endian machines (such as <see cref="BitConverter.ToString(byte[])"/>). However, <see cref="GetBytes(bool)"/> is
+    /// included for consistency.
+    /// </remarks>
+    public abstract class EndianBitConverter
+    {
+        /// <summary>
+        /// Get an instance of a <see cref="LittleEndianBitConverter"/>, a BitConverter which performs all conversions in little-endian format regardless of
+        /// machine architecture.
+        /// </summary>
+        public static EndianBitConverter LittleEndian { get; } = new LittleEndianBitConverter();
+
+        /// <summary>
+        /// Get an instance of a <see cref="BigEndianBitConverter"/>, a BitConverter which performs all conversions in big-endian format regardless of
+        /// machine architecture.
+        /// </summary>
+        public static EndianBitConverter BigEndian { get; } = new BigEndianBitConverter();
+
+        /// <summary>
+        /// Indicates the byte order ("endianness") in which data should be converted.
+        /// </summary>
+        public abstract bool IsLittleEndian { get; }
+
+        /// <summary>
+        /// Returns the specified Boolean value as a byte array.
+        /// </summary>
+        /// <param name="value">A Boolean value.</param>
+        /// <returns>A byte array with length 1.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="Boolean"/> value by calling the <see cref="ToBoolean(byte[], int)"/> method.</remarks>
+        public byte[] GetBytes(bool value)
+        {
+            return new byte[] { value ? (byte)1 : (byte)0 };
+        }
+
+        /// <summary>
+        /// Returns the specified Unicode character value as an array of bytes.
+        /// </summary>
+        /// <param name="value">A character to convert.</param>
+        /// <returns>An array of bytes with length 2.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="Char"/> value by calling the <see cref="ToChar(byte[], int)"/> method.</remarks>
+        public byte[] GetBytes(char value)
+        {
+            return this.GetBytes((short)value);
+        }
+
+        /// <summary>
+        /// Returns the specified double-precision floating point value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>An array of bytes with length 8.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="Double"/> value by calling the <see cref="ToDouble(byte[], int)"/> method.</remarks>
+        public byte[] GetBytes(double value)
+        {
+            long val = BitConverter.DoubleToInt64Bits(value);
+            return this.GetBytes(val);
+        }
+
+        /// <summary>
+        /// Returns the specified 16-bit signed integer value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>An array of bytes with length 2.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="Int16"/> value by calling the <see cref="ToInt16(byte[], int)"/> method.</remarks>
+        public abstract byte[] GetBytes(short value);
+
+        /// <summary>
+        /// Returns the specified 32-bit signed integer value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>An array of bytes with length 4.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="Int32"/> value by calling the <see cref="ToInt32(byte[], int)"/> method.</remarks>
+        public abstract byte[] GetBytes(int value);
+
+        /// <summary>
+        /// Returns the specified 64-bit signed integer value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>An array of bytes with length 8.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="Int64"/> value by calling the <see cref="ToInt64(byte[], int)"/> method.</remarks>
+        public abstract byte[] GetBytes(long value);
+
+        /// <summary>
+        /// Returns the specified single-precision floating point value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>An array of bytes with length 4.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="Single"/> value by calling the <see cref="ToSingle(byte[], int)"/> method.</remarks>
+        public byte[] GetBytes(float value)
+        {
+            int val = new SingleConverter(value).GetIntValue();
+            return this.GetBytes(val);
+        }
+
+        /// <summary>
+        /// Returns the specified 16-bit unsigned integer value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert. </param>
+        /// <returns>An array of bytes with length 2.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="UInt16"/> value by calling the <see cref="ToUInt16(byte[], int)"/> method.</remarks>
+        [CLSCompliant(false)]
+        public byte[] GetBytes(ushort value)
+        {
+            return this.GetBytes((short)value);
+        }
+
+        /// <summary>
+        /// Returns the specified 32-bit unsigned integer value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>An array of bytes with length 4.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="UInt32"/> value by calling the <see cref="ToUInt32(byte[], int)"/> method.</remarks>
+        [CLSCompliant(false)]
+        public byte[] GetBytes(uint value)
+        {
+            return this.GetBytes((int)value);
+        }
+
+        /// <summary>
+        /// Returns the specified 64-bit unsigned integer value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>An array of bytes with length 8.</returns>
+        /// <remarks>You can convert a byte array back to a <see cref="UInt64"/> value by calling the <see cref="ToUInt64(byte[], int)"/> method.</remarks>
+        [CLSCompliant(false)]
+        public byte[] GetBytes(ulong value)
+        {
+            return this.GetBytes((long)value);
+        }
+
+        /// <summary>
+        /// Returns a Boolean value converted from the byte at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">A byte array.</param>
+        /// <param name="startIndex">The index of the byte within <paramref name="value"/>.</param>
+        /// <returns>
+        /// true if the byte at <paramref name="startIndex"/> in <paramref name="value"/> is nonzero; otherwise, false.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 1.
+        /// </exception>
+        public bool ToBoolean(byte[] value, int startIndex)
+        {
+            this.CheckArguments(value, startIndex, 1);
+
+            return value[startIndex] != 0;
+        }
+
+        /// <summary>
+        /// Returns a Unicode character converted from two bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array.</param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A character formed by two bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToChar method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 1 to a <see cref="Char"/> value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 2.
+        /// </exception>
+        public char ToChar(byte[] value, int startIndex)
+        {
+            return (char)this.ToInt16(value, startIndex);
+        }
+
+        /// <summary>
+        /// Returns a double-precision floating point number converted from eight bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes.</param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A double precision floating point number formed by eight bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToDouble method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 7 to a <see cref="Double"/>
+        /// value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 8.
+        /// </exception>
+        public double ToDouble(byte[] value, int startIndex)
+        {
+            long val = this.ToInt64(value, startIndex);
+            return BitConverter.Int64BitsToDouble(val);
+        }
+
+        /// <summary>
+        /// Returns a 16-bit signed integer converted from two bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes.</param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A 16-bit signed integer formed by two bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToInt16 method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 1 to an <see cref="Int16"/>
+        /// value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 2.
+        /// </exception>
+        public abstract short ToInt16(byte[] value, int startIndex);
+
+        /// <summary>
+        /// Returns a 32-bit signed integer converted from four bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes. </param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A 32-bit signed integer formed by four bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToInt32 method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 3 to an <see cref="Int32"/>
+        /// value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 4.
+        /// </exception>
+        public abstract int ToInt32(byte[] value, int startIndex);
+
+        /// <summary>
+        /// Returns a 64-bit signed integer converted from eight bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes.</param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A 64-bit signed integer formed by eight bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToInt64 method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 7 to an <see cref="Int64"/>
+        /// value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 8.
+        /// </exception>
+        public abstract long ToInt64(byte[] value, int startIndex);
+
+        /// <summary>
+        /// Returns a single-precision floating point number converted from four bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes.</param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A single-precision floating point number formed by four bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToSingle method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 3 to a <see cref="Single"/>
+        /// value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 4.
+        /// </exception>
+        public float ToSingle(byte[] value, int startIndex)
+        {
+            int val = this.ToInt32(value, startIndex);
+            return new SingleConverter(val).GetFloatValue();
+        }
+
+        /// <summary>
+        /// Returns a 16-bit unsigned integer converted from two bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A 16-bit unsigned integer formed by two bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToUInt16 method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 1 to a <see cref="UInt16"/>
+        /// value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 2.
+        /// </exception>
+        [CLSCompliant(false)]
+        public ushort ToUInt16(byte[] value, int startIndex)
+        {
+            return (ushort)this.ToInt16(value, startIndex);
+        }
+
+        /// <summary>
+        /// Returns a 32-bit unsigned integer converted from four bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes. </param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A 32-bit unsigned integer formed by four bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToUInt32 method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 3 to a <see cref="UInt32"/>
+        /// value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 4.
+        /// </exception>
+        [CLSCompliant(false)]
+        public uint ToUInt32(byte[] value, int startIndex)
+        {
+            return (uint)this.ToInt32(value, startIndex);
+        }
+
+        /// <summary>
+        /// Returns a 64-bit unsigned integer converted from eight bytes at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes. </param>
+        /// <param name="startIndex">The starting position within <paramref name="value"/>.</param>
+        /// <returns>A 64-bit unsigned integer formed by the eight bytes beginning at <paramref name="startIndex"/>.</returns>
+        /// <remarks>
+        /// The ToUInt64 method converts the bytes from index <paramref name="startIndex"/> to <paramref name="startIndex"/> + 7 to a <see cref="UInt64"/>
+        /// value.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="value"/> minus 8.
+        /// </exception>
+        [CLSCompliant(false)]
+        public ulong ToUInt64(byte[] value, int startIndex)
+        {
+            return (ulong)this.ToInt64(value, startIndex);
+        }
+
+        // Testing showed that this method wasn't automatically being inlined, and doing so offers a significant performance improvement.
+#if !NET40
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal void CheckArguments(byte[] value, int startIndex, int byteLength)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            // confirms startIndex is not negative or too far along the byte array
+            if ((uint)startIndex > value.Length - byteLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+        }
+    }
+}

--- a/Src/EndianBitConverter/EndianBitConverter.csproj
+++ b/Src/EndianBitConverter/EndianBitConverter.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{39070DFB-3AC8-4B56-AF4B-1179EDEB038A}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>EndianBitConverter</RootNamespace>
+        <AssemblyName>EndianBitConverter</AssemblyName>
+        <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="BigEndianBitConverter.cs" />
+        <Compile Include="EndianBitConverter.cs" />
+        <Compile Include="LittleEndianBitConverter.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="SingleConverter.cs" />
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+</Project>

--- a/Src/EndianBitConverter/LittleEndianBitConverter.cs
+++ b/Src/EndianBitConverter/LittleEndianBitConverter.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+namespace EndianBitConverter
+{
+    /// <summary>
+    /// A little-endian BitConverter that converts base data types to an array of bytes, and an array of bytes to base data types. All conversions are in
+    /// little-endian format regardless of machine architecture.
+    /// </summary>
+    internal class LittleEndianBitConverter : EndianBitConverter
+    {
+        // Instance available from EndianBitConverter.LittleEndian
+        internal LittleEndianBitConverter() { }
+
+        public override bool IsLittleEndian { get; } = true;
+
+        public override byte[] GetBytes(short value)
+        {
+            return new byte[] { (byte)value, (byte)(value >> 8) };
+        }
+
+        public override byte[] GetBytes(int value)
+        {
+            return new byte[] { (byte)value, (byte)(value >> 8), (byte)(value >> 16), (byte)(value >> 24) };
+        }
+
+        public override byte[] GetBytes(long value)
+        {
+            return new byte[] {
+                (byte)value, (byte)(value >> 8), (byte)(value >> 16), (byte)(value >> 24),
+                (byte)(value >> 32), (byte)(value >> 40), (byte)(value >> 48), (byte)(value >> 56)
+            };
+        }
+
+        public override short ToInt16(byte[] value, int startIndex)
+        {
+            this.CheckArguments(value, startIndex, sizeof(short));
+
+            return (short)((value[startIndex]) | (value[startIndex + 1] << 8));
+        }
+
+        public override int ToInt32(byte[] value, int startIndex)
+        {
+            this.CheckArguments(value, startIndex, sizeof(int));
+
+            return (value[startIndex]) | (value[startIndex + 1] << 8) | (value[startIndex + 2] << 16) | (value[startIndex + 3] << 24);
+        }
+
+        public override long ToInt64(byte[] value, int startIndex)
+        {
+            this.CheckArguments(value, startIndex, sizeof(long));
+
+            int lowBytes = (value[startIndex]) | (value[startIndex + 1] << 8) | (value[startIndex + 2] << 16) | (value[startIndex + 3] << 24);
+            int highBytes = (value[startIndex + 4]) | (value[startIndex + 5] << 8) | (value[startIndex + 6] << 16) | (value[startIndex + 7] << 24);
+            return ((uint)lowBytes | ((long)highBytes << 32));
+        }
+    }
+}

--- a/Src/EndianBitConverter/Properties/AssemblyInfo.cs
+++ b/Src/EndianBitConverter/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EndianBitConverter")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EndianBitConverter")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("39070DFB-3AC8-4B56-AF4B-1179EDEB038A")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Src/EndianBitConverter/SingleConverter.cs
+++ b/Src/EndianBitConverter/SingleConverter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System.Runtime.InteropServices;
+
+namespace EndianBitConverter
+{
+    // Converts between Single (float) and Int32 (int), as System.BitConverter does not have a method to do this in all .NET versions.
+    // A union is used instead of an unsafe pointer cast so we don't have to worry about the trusted environment implications.
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct SingleConverter
+    {
+        // map int value to offset zero
+        [FieldOffset(0)]
+        private int intValue;
+
+        // map float value to offset zero - intValue and floatValue now take the same position in memory
+        [FieldOffset(0)]
+        private float floatValue;
+
+        internal SingleConverter(int intValue)
+        {
+            this.floatValue = 0;
+            this.intValue = intValue;
+        }
+
+        internal SingleConverter(float floatValue)
+        {
+            this.intValue = 0;
+            this.floatValue = floatValue;
+        }
+
+        internal int GetIntValue() => this.intValue;
+
+        internal float GetFloatValue() => this.floatValue;
+    }
+}


### PR DESCRIPTION
在Utils中添加了AV号与BV号的转换功能
决定添加对NETFramework 4.7.1和NETStandard 2.0的支持
兼容Unity,可在Unity中使用该代码、

**有部分代码拷贝来自**[BitConverter](https://github.com/davidrea-MS/BitConverter)